### PR TITLE
Review of new Transactional API, Java implementation

### DIFF
--- a/samples/com/createsend/samples/TransactionalSample.java
+++ b/samples/com/createsend/samples/TransactionalSample.java
@@ -42,7 +42,7 @@ import java.util.UUID;
  */
 public class TransactionalSample {
 
-    private static OAuthAuthenticationDetails auth = new OAuthAuthenticationDetails("your access token", "your refresh token");
+    private static final OAuthAuthenticationDetails auth = new OAuthAuthenticationDetails("your access token", "your refresh token");
 
     private static final UUID smartEmailID = UUID.fromString("your smart email id");
     private static final UUID messageID = UUID.fromString("your message id");
@@ -51,6 +51,7 @@ public class TransactionalSample {
     private static final String replyToAddress = "you@example.com";
     private static final String subject = "java transactional api wrapper";
     private static final String group = "java wrapper emails";
+    private static final String clientID = "your client id"; // Can be null
 
     public static void main(String args[]) throws CreateSendException, IOException {
         listSmartEmails();
@@ -59,8 +60,7 @@ public class TransactionalSample {
         listGroups();
         sendClassicEmail();
 
-        resend();
-
+        resendMessage();
         getMessage();
 
         showStatistics();
@@ -73,7 +73,7 @@ public class TransactionalSample {
 
         Messages messages = new Messages(auth);
 
-        MessageLogItem[] timeline = messages.timeline(null, null, null, 50, null, null, null);
+        MessageLogItem[] timeline = messages.timeline(clientID, null, null, 50, null, null, null);
 
         for (MessageLogItem item : timeline) {
             System.out.println(item);
@@ -85,7 +85,7 @@ public class TransactionalSample {
 
         Messages messages = new Messages(auth);
 
-        TransactionalStatistics stats = messages.statistics(null, smartEmailID, null, null, null, null);
+        TransactionalStatistics stats = messages.statistics(clientID, smartEmailID, null, null, null, null);
 
         System.out.println(stats);
     }
@@ -131,7 +131,7 @@ public class TransactionalSample {
 
         ClassicEmail classicEmail = new ClassicEmail(auth);
 
-        ClassicEmailGroup[] groups = classicEmail.list();
+        ClassicEmailGroup[] groups = classicEmail.list(clientID);
 
         for (ClassicEmailGroup group : groups) {
             System.out.printf("Classic Email: %s\n", group);
@@ -142,7 +142,7 @@ public class TransactionalSample {
         System.out.println("---- List Smart Emails ----");
 
         SmartEmail smartEmail = new SmartEmail(auth);
-        SmartEmailItem[] smartEmails = smartEmail.list();
+        SmartEmailItem[] smartEmails = smartEmail.list(clientID);
 
         boolean hasGotFirst = false;
         for (SmartEmailItem status : smartEmails) {
@@ -176,8 +176,8 @@ public class TransactionalSample {
         smartEmail.send(smartEmailRequest);
     }
 
-    private static void resend() throws CreateSendException {
-        System.out.println("---- Resend Email ----");
+    private static void resendMessage() throws CreateSendException {
+        System.out.println("---- Resend Message ----");
 
         Messages messages = new Messages(auth);
         messages.resend(messageID);

--- a/src/com/createsend/ClassicEmail.java
+++ b/src/com/createsend/ClassicEmail.java
@@ -23,6 +23,7 @@ package com.createsend;
 
 import com.createsend.models.transactional.request.ClassicEmailRequest;
 import com.createsend.models.transactional.response.ClassicEmailGroup;
+import com.createsend.models.transactional.response.MessageSent;
 import com.createsend.util.AuthenticationDetails;
 import com.createsend.util.JerseyClientImpl;
 import com.createsend.util.exceptions.CreateSendException;
@@ -32,7 +33,7 @@ import javax.ws.rs.core.MultivaluedMap;
 
 /**
  * Provides methods for accessing all <a href="http://www.campaignmonitor.com/api/transactional/classicEmail/" target="_blank">
- * Campaign</a> resources in the Campaign Monitor API
+ * Transactional Classic Email</a> resources in the Campaign Monitor API
  */
 public class ClassicEmail extends CreateSendBase {
 
@@ -83,15 +84,16 @@ public class ClassicEmail extends CreateSendBase {
      * Send a ClassicEmail.
      * @param classicEmailRequest The ClassicEmailRequest to send.
      * @param clientID The ClientID to filter.
+     * @return Message sent acknowledgement.
      * @throws CreateSendException
      */
-    public void send(ClassicEmailRequest classicEmailRequest, String clientID) throws CreateSendException {
+    public MessageSent[] send(ClassicEmailRequest classicEmailRequest, String clientID) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl();
 
         if (clientID != null) {
             queryString.add("clientID", clientID);
         }
 
-        jerseyClient.post(String.class, queryString, classicEmailRequest, "transactional", "classicEmail", "send");
+        return jerseyClient.post(MessageSent[].class, queryString, classicEmailRequest, "transactional", "classicEmail", "send");
     }
 }

--- a/src/com/createsend/Messages.java
+++ b/src/com/createsend/Messages.java
@@ -23,6 +23,7 @@ package com.createsend;
 
 import com.createsend.models.transactional.response.Message;
 import com.createsend.models.transactional.response.MessageLogItem;
+import com.createsend.models.transactional.response.MessageSent;
 import com.createsend.models.transactional.response.TransactionalStatistics;
 import com.createsend.util.AuthenticationDetails;
 import com.createsend.util.JerseyClientImpl;
@@ -120,10 +121,11 @@ public class Messages extends CreateSendBase {
     /**
      * Resend a message. Message may have a retention limit and might not always be valid to resend.
      * @param messageID the message id to resend.
+     * @return Message sent acknowledgement.
      * @throws CreateSendException
      */
-    public void resend(UUID messageID) throws CreateSendException {
-        jerseyClient.post(String.class, (Object)null, "transactional", "messages", messageID.toString(), "resend");
+    public MessageSent resend(UUID messageID) throws CreateSendException {
+        return jerseyClient.post(MessageSent.class, (Object)null, "transactional", "messages", messageID.toString(), "resend");
     }
 
     /**

--- a/src/com/createsend/Messages.java
+++ b/src/com/createsend/Messages.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 
 /**
  * Provides methods for accessing all <a href="http://www.campaignmonitor.com/api/transactional/messages/" target="_blank">
- * Campaign</a> resources in the Campaign Monitor API
+ * Transactional Message</a> resources in the Campaign Monitor API
  */
 public class Messages extends CreateSendBase {
 
@@ -97,7 +97,8 @@ public class Messages extends CreateSendBase {
             queryString.add("group", group);
         }
 
-        final DateFormat dateFormat = new SimpleDateFormat("yyyy-mm-dd");
+        // TODO Constant somewhere (JsonProvider.ApiDateFormatNoTime?)
+        final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 
         if (from != null) {
             String fromStr = dateFormat.format(from);

--- a/src/com/createsend/Messages.java
+++ b/src/com/createsend/Messages.java
@@ -138,7 +138,7 @@ public class Messages extends CreateSendBase {
      * @return
      * @throws CreateSendException
      */
-    public MessageLogItem[] timeline(String clientID, UUID sentBeforeID, UUID sentAfterID, int count, String status, UUID smartEmailID, String group) throws CreateSendException {
+    public MessageLogItem[] timeline(String clientID, UUID sentBeforeID, UUID sentAfterID, Integer count, String status, UUID smartEmailID, String group) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl();
 
         if (clientID != null) {
@@ -153,8 +153,8 @@ public class Messages extends CreateSendBase {
             queryString.add("sentAfterID", sentAfterID.toString());
         }
 
-        if (count > 0 && count < 200) {
-            queryString.add("count", String.valueOf(count));
+        if (count != null) {
+            queryString.add("count", count.toString());
         }
 
         if (status != null) {

--- a/src/com/createsend/SmartEmail.java
+++ b/src/com/createsend/SmartEmail.java
@@ -22,6 +22,7 @@
 package com.createsend;
 
 import com.createsend.models.transactional.request.SmartEmailRequest;
+import com.createsend.models.transactional.response.MessageSent;
 import com.createsend.models.transactional.response.SmartEmailDetails;
 import com.createsend.models.transactional.response.SmartEmailItem;
 import com.createsend.models.transactional.response.SmartEmailStatus;
@@ -110,9 +111,10 @@ public class SmartEmail extends CreateSendBase {
     /**
      * Send a SmartEmail.
      * @param smartEmailRequest The SmartEmailRequest to send.
+     * @return Message sent acknowledgement.
      * @throws CreateSendException
      */
-    public void send(SmartEmailRequest smartEmailRequest) throws CreateSendException {
-        jerseyClient.post(String.class, smartEmailRequest, "transactional", "smartEmail", smartEmailRequest.getSmartEmailId().toString(), "send");
+    public MessageSent[] send(SmartEmailRequest smartEmailRequest) throws CreateSendException {
+        return jerseyClient.post(MessageSent[].class, smartEmailRequest, "transactional", "smartEmail", smartEmailRequest.getSmartEmailId().toString(), "send");
     }
 }

--- a/src/com/createsend/SmartEmail.java
+++ b/src/com/createsend/SmartEmail.java
@@ -35,11 +35,9 @@ import java.util.UUID;
 
 /**
  * Provides methods for accessing all <a href="http://www.campaignmonitor.com/api/transactional/smartEmail/" target="_blank">
- * Campaign</a> resources in the Campaign Monitor API
+ * Transactional Smart Email</a> resources in the Campaign Monitor API
  */
 public class SmartEmail extends CreateSendBase {
-
-    private static final SmartEmailStatus defaultStatus = SmartEmailStatus.ACTIVE;
 
     /**
      * @param auth The authentication details to use when making API calls.
@@ -56,7 +54,7 @@ public class SmartEmail extends CreateSendBase {
      * @throws CreateSendException
      */
     public SmartEmailItem[] list() throws CreateSendException {
-        return list(defaultStatus);
+        return list(null, null);
     }
 
     /**
@@ -70,6 +68,16 @@ public class SmartEmail extends CreateSendBase {
     }
 
     /**
+     * List SmartEmails, filtered for a specific Client.
+     * @param clientID
+     * @return
+     * @throws CreateSendException
+     */
+    public SmartEmailItem[] list(String clientID) throws CreateSendException {
+        return list(null, clientID);
+    }
+
+    /**
      * List SmartEmails, filtered by status for a specific Client.
      * @param status
      * @param clientID
@@ -78,7 +86,9 @@ public class SmartEmail extends CreateSendBase {
      */
     public SmartEmailItem[] list(SmartEmailStatus status, String clientID) throws CreateSendException {
         MultivaluedMap<String, String> queryString = new MultivaluedMapImpl();
-        queryString.add("status", status.toValue());
+        if (status != null) {
+            queryString.add("status", status.toValue());
+        }
 
         if (clientID != null) {
             queryString.add("clientID", clientID);

--- a/src/com/createsend/models/transactional/EmailContent.java
+++ b/src/com/createsend/models/transactional/EmailContent.java
@@ -23,6 +23,8 @@ package com.createsend.models.transactional;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
+import java.util.List;
+
 public class EmailContent {
 
     @JsonProperty("Html")
@@ -30,6 +32,9 @@ public class EmailContent {
 
     @JsonProperty("Text")
     private String text;
+
+    @JsonProperty("EmailVariables")
+    private List<String> emailVariables;
 
     @JsonProperty("InlineCss")
     private boolean inlineCss;
@@ -52,6 +57,13 @@ public class EmailContent {
      */
     public String getText() {
         return text;
+    }
+
+    /**
+     * @return the data merge variables.
+     */
+    public List<String> getEmailVariables() {
+        return emailVariables;
     }
 
     /**

--- a/src/com/createsend/models/transactional/request/ClassicEmailRequest.java
+++ b/src/com/createsend/models/transactional/request/ClassicEmailRequest.java
@@ -23,7 +23,6 @@ package com.createsend.models.transactional.request;
 
 import com.createsend.models.transactional.EmailContent;
 
-import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -104,7 +103,7 @@ public class ClassicEmailRequest {
 
     public ClassicEmailRequest(String to) {
         if (to == null || to.length() == 0) {
-            throw new InvalidParameterException("Must supply a TO address");
+            throw new IllegalArgumentException("Must supply a TO address");
         }
 
         this.to.add(to);

--- a/src/com/createsend/models/transactional/request/SmartEmailRequest.java
+++ b/src/com/createsend/models/transactional/request/SmartEmailRequest.java
@@ -24,7 +24,6 @@ package com.createsend.models.transactional.request;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonUnwrapped;
 
-import java.security.InvalidParameterException;
 import java.util.*;
 
 public class SmartEmailRequest {
@@ -44,11 +43,11 @@ public class SmartEmailRequest {
      */
     public SmartEmailRequest(UUID smartEmailId, String to) {
         if (smartEmailId == null) {
-            throw new InvalidParameterException("Must supply a Smart Email ID");
+            throw new IllegalArgumentException("Must supply a Smart Email ID");
         }
 
         if (to == null || to.length() == 0) {
-            throw new InvalidParameterException("Must supply a TO address");
+            throw new IllegalArgumentException("Must supply a TO address");
         }
 
         this.smartEmailId = smartEmailId;

--- a/src/com/createsend/models/transactional/response/Message.java
+++ b/src/com/createsend/models/transactional/response/Message.java
@@ -23,6 +23,7 @@ package com.createsend.models.transactional.response;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -32,6 +33,9 @@ public class Message {
 
     @JsonProperty("Status")
     private String status;
+
+    @JsonProperty("SentAt")
+    private Date sentAt;
 
     @JsonProperty("SmartEmailID")
     private UUID smartEmailId;
@@ -69,6 +73,13 @@ public class Message {
      */
     public String getStatus() {
         return status;
+    }
+
+    /**
+     * @return the message sentAt.
+     */
+    public Date getSentAt() {
+        return sentAt;
     }
 
     /**

--- a/src/com/createsend/models/transactional/response/MessageLogItem.java
+++ b/src/com/createsend/models/transactional/response/MessageLogItem.java
@@ -48,6 +48,12 @@ public class MessageLogItem {
     @JsonProperty("Recipient")
     private String recipient;
 
+    @JsonProperty("From")
+    private String from;
+
+    @JsonProperty("Subject")
+    private String subject;
+
     @JsonProperty("TotalOpens")
     private int totalOpens;
 
@@ -101,6 +107,20 @@ public class MessageLogItem {
      */
     public String getRecipient() {
         return recipient;
+    }
+
+    /**
+     * @return the from address of the message.
+     */
+    public String getFrom() {
+        return from;
+    }
+
+    /**
+     * @return the subject of the message.
+     */
+    public String getSubject() {
+        return subject;
     }
 
     /**

--- a/src/com/createsend/models/transactional/response/MessageSent.java
+++ b/src/com/createsend/models/transactional/response/MessageSent.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2015 Richard Bremner
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.createsend.models.transactional.response;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public class MessageSent {
+    @JsonProperty("MessageID")
+    private UUID messageID;
+
+    @JsonProperty("Status")
+    private String status;
+
+    @JsonProperty("Recipient")
+    private String recipient;
+
+    /**
+     * @return the message id.
+     */
+    public UUID getMessageID() {
+        return messageID;
+    }
+
+    /**
+     * @return the message delivery status.
+     */
+    public String getStatus() {
+        return status;
+    }
+
+    /**
+     * @return the recipient of the message.
+     */
+    public String getRecipient() {
+        return recipient;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("MessageID: %s, Status: %s, Recipient: %s", messageID, status, recipient);
+    }
+}

--- a/src/com/createsend/models/transactional/response/SmartEmailDetails.java
+++ b/src/com/createsend/models/transactional/response/SmartEmailDetails.java
@@ -36,6 +36,9 @@ public class SmartEmailDetails {
     @JsonProperty("Status")
     private String status;
 
+    @JsonProperty("Name")
+    private String name;
+
     @JsonProperty("Properties")
     private SmartEmailProperties properties;
 
@@ -64,6 +67,13 @@ public class SmartEmailDetails {
     }
 
     /**
+     * @return the name of the smart email.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
      * @return smart email properties.
      */
     public SmartEmailProperties getProperties() {
@@ -79,6 +89,6 @@ public class SmartEmailDetails {
 
     @Override
     public String toString() {
-        return String.format("ID: %s, Status: %s, Properties:\n%s", getSmartEmailID(), getStatus(), getProperties());
+        return String.format("ID: %s, Status: %s, Name: %s, Properties:\n%s", getSmartEmailID(), getStatus(), getName(), getProperties());
     }
 }

--- a/src/com/createsend/models/transactional/response/SmartEmailProperties.java
+++ b/src/com/createsend/models/transactional/response/SmartEmailProperties.java
@@ -29,6 +29,9 @@ public class SmartEmailProperties {
     @JsonProperty("From")
     private String from;
 
+    @JsonProperty("ReplyTo")
+    private String replyTo;
+
     @JsonProperty("Subject")
     private String subject;
 
@@ -46,6 +49,13 @@ public class SmartEmailProperties {
      */
     public String getFrom() {
         return from;
+    }
+
+    /**
+     * @return the replyTo address of the smart email.
+     */
+    public String getReplyTo() {
+        return replyTo;
     }
 
     /**

--- a/src/com/createsend/util/Configuration.java
+++ b/src/com/createsend/util/Configuration.java
@@ -21,6 +21,7 @@
  */
 package com.createsend.util;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -33,7 +34,11 @@ public class Configuration {
         properties = new Properties();
 
         try {
-            properties.load(getClass().getClassLoader().getResourceAsStream("com/createsend/util/config.properties"));
+            InputStream configProperties = getClass().getClassLoader().getResourceAsStream("com/createsend/util/config.properties");
+            if (configProperties == null) {
+                throw new FileNotFoundException("Could not find config.properties");
+            }
+            properties.load(configProperties);
                         
             InputStream createsendProperties = getClass().getClassLoader().getResourceAsStream("createsend.properties");
             if(createsendProperties != null) {

--- a/src/com/createsend/util/jersey/JsonProvider.java
+++ b/src/com/createsend/util/jersey/JsonProvider.java
@@ -52,12 +52,6 @@ public class JsonProvider extends JacksonJsonProvider {
         final SimpleDateFormat ApiDateFormatTz = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
 
         @Override
-        public StringBuffer format(Date date, StringBuffer toAppendTo, FieldPosition fieldPosition) {
-            // FIXME this will break Campaigns, Lists and Segments methods that use ApiDateFormat
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public Date parse(String source, ParsePosition pos) {
             if (source.length() - pos.getIndex() == ApiDateFormat.toPattern().length())
                 return ApiDateFormat.parse(source, pos);

--- a/src/com/createsend/util/jersey/JsonProvider.java
+++ b/src/com/createsend/util/jersey/JsonProvider.java
@@ -53,6 +53,7 @@ public class JsonProvider extends JacksonJsonProvider {
 
         @Override
         public StringBuffer format(Date date, StringBuffer toAppendTo, FieldPosition fieldPosition) {
+            // FIXME this will break Campaigns, Lists and Segments methods that use ApiDateFormat
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
Hi @richardbremner, a bunch of suggestions and some fixes, as discussed.

The first suggestion, to be explicit about `config.properties` not being found, isn't Transactional related but I thought it was a worthwhile change, as it initially tripped me up trying to run the samples.

Another review should be done once the API docs are finalised as I found quite a few differences with the code. Two things of note:
- Where possible I relied on the default values the API endpoints provided, rather than instituting them in the wrapper. E.g. the `count` parameter of the Messages Timeline method.
- The Smart Email Details call returns in the `EmailContent` response a `List<String>` for `emailVariables`. I think we were under the impression it should be a `Map<String, String>`.
